### PR TITLE
fixed "error: unexpected token "get_local"" in unit tests

### DIFF
--- a/test/test_generic.py
+++ b/test/test_generic.py
@@ -7,16 +7,16 @@ FIB64_WASM = wat2wasm("""
 (module
   (func $fib2 (param $n i64) (param $a i64) (param $b i64) (result i64)
     (if (result i64)
-        (i64.eqz (get_local $n))
-        (then (get_local $a))
-        (else (return_call $fib2 (i64.sub (get_local $n)
+        (i64.eqz (local.get $n))
+        (then (local.get $a))
+        (else (return_call $fib2 (i64.sub (local.get $n)
                                    (i64.const 1))
-                          (get_local $b)
-                          (i64.add (get_local $a)
-                                   (get_local $b))))))
+                          (local.get $b)
+                          (i64.add (local.get $a)
+                                   (local.get $b))))))
 
   (func $fib (export "fib") (param i64) (result i64)
-    (return_call $fib2 (get_local 0)
+    (return_call $fib2 (local.get 0)
                 (i64.const 0)   ;; seed value $a
                 (i64.const 1))) ;; seed value $b
 )

--- a/test/test_multivalue.py
+++ b/test/test_multivalue.py
@@ -6,8 +6,8 @@ from helpers import wat2wasm
 MV_SWAP_WASM = wat2wasm("""
 (module
   (func (export "swap") (param i32 i32) (result i32 i32)
-    (get_local 1)
-    (get_local 0)
+    (local.get 1)
+    (local.get 0)
   )
 )
 """)
@@ -17,8 +17,8 @@ MV_IMPORT_WASM = wat2wasm("""
   (type $t0 (func (param i32 i64) (result i64 i32)))
   (import "env" "swap" (func $env.swap (type $t0)))
   (func (export "swap") (type $t0)
-    (get_local 0)
-    (get_local 1)
+    (local.get 0)
+    (local.get 1)
     (call $env.swap)
   )
 )


### PR DESCRIPTION
`get_local` is replaced with `local.get` and causes error in unit tests with current WABT. See https://github.com/mdn/webassembly-examples/issues/17